### PR TITLE
addressing issue with npm postinstall script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "postinstall": "cd backend; npm install",
+    "postinstall": "cd backend && npm install",
     "start": "npm run start.web",
     "start.web": "ng serve --app=web",
     "start.ios": "cd apps/mobile && tns run ios --emulator --syncAllFiles",


### PR DESCRIPTION
Windows doesn't like the `;` for commands. switched to `&&` so installs will work on Windows Command prompt.