### PR TITLE
Adding Collapse effect to search bar for speaker list.

### DIFF
--- a/apps/mobile/app/modules/shared/directives/collapse.directive.ts
+++ b/apps/mobile/app/modules/shared/directives/collapse.directive.ts
@@ -1,0 +1,73 @@
+import { Directive, ElementRef, Input, AfterViewInit } from '@angular/core';
+import { View } from 'tns-core-modules/ui/core/view';
+import { PanGestureEventData } from 'tns-core-modules/ui/gestures';
+
+import { fromEvent } from 'rxjs/observable/fromEvent';
+import { Subscription } from 'rxjs/Subscription';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/distinctUntilChanged';
+import { fromPromise } from 'rxjs/observable/fromPromise';
+
+@Directive({
+	selector: '[collapse]'
+})
+export class CollapseDirective implements AfterViewInit {
+
+	private subscription: Subscription;
+
+	@Input() collapse: ElementRef;
+
+	get view(): View {
+		return this.element.nativeElement;
+	}
+
+	get listView(): View {
+		return this.collapse.nativeElement;
+	}
+
+	constructor(private element: ElementRef) {
+	}
+
+	ngAfterViewInit() {
+		const emptyFunction = () => { };
+
+		const panEvent$ = fromEvent(this.listView, 'pan')
+			.map((event: PanGestureEventData) => event.deltaY);
+
+		this.subscription = panEvent$
+			.filter(deltaY => {
+				// filter out out events that are just starting
+				if (deltaY < -10) {
+					return true;
+				}
+				if (deltaY > 10) {
+					return true;
+				}
+				return false;
+			})
+			.map(deltaY => {
+				return deltaY > 0 ? 1 : 0;
+			})
+			.distinctUntilChanged()
+			.switchMap((up) => {
+				const itemHeight = this.view.getMeasuredHeight();
+				if (up) {
+					return fromPromise(this.view.animate({
+						translate: { x: 0, y: 0 },
+						duration: 600
+					}));
+
+				} else {
+					return fromPromise(this.view.animate({
+						translate: { x: 0, y: -itemHeight },
+						duration: 600
+					}));
+				}
+			}).subscribe();
+	}
+
+	ngOnDestroy() {
+		this.subscription.unsubscribe();
+	}
+}

--- a/apps/mobile/app/modules/shared/directives/collapse.directive.ts
+++ b/apps/mobile/app/modules/shared/directives/collapse.directive.ts
@@ -16,13 +16,16 @@ export class CollapseDirective implements AfterViewInit {
 
 	private subscription: Subscription;
 
+    /**
+     * listview view to watch scrolling events on.
+     */
 	@Input() collapse: ElementRef;
 
-	get view(): View {
+	private get view(): View {
 		return this.element.nativeElement;
 	}
 
-	get listView(): View {
+	private get listView(): View {
 		return this.collapse.nativeElement;
 	}
 
@@ -30,8 +33,6 @@ export class CollapseDirective implements AfterViewInit {
 	}
 
 	ngAfterViewInit() {
-		const emptyFunction = () => { };
-
 		const panEvent$ = fromEvent(this.listView, 'pan')
 			.map((event: PanGestureEventData) => event.deltaY);
 
@@ -46,7 +47,8 @@ export class CollapseDirective implements AfterViewInit {
 				}
 				return false;
 			})
-			.map(deltaY => {
+            .map( deltaY => {
+                // determine if we are moving up or not.
 				return deltaY > 0 ? 1 : 0;
 			})
 			.distinctUntilChanged()

--- a/apps/mobile/app/modules/shared/directives/index.ts
+++ b/apps/mobile/app/modules/shared/directives/index.ts
@@ -1,5 +1,7 @@
 import { TouchColorDirective } from './touch-color.directive';
+import { CollapseDirective } from './collapse.directive';
 
 export const SHARED_DIRECTIVES = [
-  TouchColorDirective
+  TouchColorDirective,
+  CollapseDirective
 ];

--- a/apps/mobile/app/modules/speakers/components/speaker.component.html
+++ b/apps/mobile/app/modules/speakers/components/speaker.component.html
@@ -1,15 +1,19 @@
 <ngatl-ns-action-bar [title]="'menu.speakers' | translate"></ngatl-ns-action-bar>
 <StackLayout class="page h-full p-b-20" (loaded)="onBackgroundLoaded($event)" *ngIf="renderView">
   <!-- Search -->
-  <SearchBar id="search" #search hint="Search" text="" (clear)="clear($event)" (submit)="search$.next(search.text)"
-   (loaded)="doNotShowAndroidKeyboard($event)" android:height="40"></SearchBar>
-  <ListView [items]="speakerState$ | async" class="list-group h-full">
-    <ng-template let-item="item" let-odd="odd" let-even="even">
-      <StackLayout class="card" (tap)="openDetail(item)">
-        <Image [src]="item.image" horizontalAlignment="center" class="w-full" backgroundColor="#fff"></Image>
-        <!-- <StackLayout class="hr-light"></StackLayout> -->
-        <Label [text]="item.name" class="text-center t-30 c-grey-dark font-weight-bold m-t-5"></Label>
-      </StackLayout>
-    </ng-template>
-  </ListView>
+  <AbsoluteLayout>
+    <ListView #speakerList width="100%" top="0" left="0" [items]="speakerState$ | async" class="list-group h-full">
+      <ng-template let-item="item" let-odd="odd" let-even="even" let-index="index">
+        <StackLayout [class.first-item]="index == 0" class="card" (tap)="openDetail(item)">
+          <Image [src]="item.image" horizontalAlignment="center" class="w-full" backgroundColor="#fff"></Image>
+          <!-- <StackLayout class="hr-light"></StackLayout> -->
+          <Label [text]="item.name" class="text-center t-30 c-grey-dark font-weight-bold m-t-5"></Label>
+        </StackLayout>
+      </ng-template>
+    </ListView>
+    <StackLayout [collapse]="speakerList" class="search-bar" width="100%">
+      <SearchBar top="0" left="0" id="search" #search hint="Search" text="" (clear)="clear($event)" (submit)="search$.next(search.text)"
+        (loaded)="doNotShowAndroidKeyboard($event)" android:height="40"></SearchBar>
+    </StackLayout>
+  </AbsoluteLayout>
 </StackLayout>

--- a/apps/mobile/app/scss/_common.scss
+++ b/apps/mobile/app/scss/_common.scss
@@ -301,7 +301,7 @@ ListView {
     &.level-gold {
         background-color: #ffb720;
     }
-    
+
 }
 
 .about-bg {
@@ -339,3 +339,9 @@ ListView {
 //     background-color: $black;
 //     margin-bottom:    20;
 //   }
+.search-bar{
+    background-color:rgba(21,31,47,.8);
+}
+.first-item{
+    padding-top: 50;
+}


### PR DESCRIPTION
Adds a collapsing effect to the speaker search bar. When scrolling down the list view the search bar is hidden from view. As soon as the user starts scrolling up the search bar is visible. 

they say a picture is worth a thousand words. 
![collapse](https://user-images.githubusercontent.com/1486275/34917094-b9c1b118-f90f-11e7-963f-f853a128c682.gif)
