### PR TITLE
Adding drop shadows to list item cards. 

### DIFF
--- a/apps/mobile/app/modules/misc/components/community.component.html
+++ b/apps/mobile/app/modules/misc/components/community.component.html
@@ -2,12 +2,14 @@
 <StackLayout class="page h-full p-b-20" *ngIf="renderView">
   <ListView [items]="communityState$ | async" class="list-group h-full">
     <ng-template let-item="item" let-odd="odd" let-even="even">
-      <StackLayout class="card" (tap)="viewSite(item.link, item.name)">
-        <Image [src]="item.logo" height="120" horizontalAlignment="center" verticalAlignment="center" class="w-full p-5 c-bg-white"></Image>
-        
-        <!-- <StackLayout class="hr-light"></StackLayout> -->
-        <Label [text]="item.name" class="text-center t-20 w-full c-black p-5 font-weight-bold"></Label>
+      <StackLayout shadow="5">
+        <StackLayout class="card" (tap)="viewSite(item.link, item.name)">
+          <Image [src]="item.logo" height="120" horizontalAlignment="center" verticalAlignment="center" class="w-full p-5 c-bg-white"></Image>
+
+          <!-- <StackLayout class="hr-light"></StackLayout> -->
+          <Label [text]="item.name" class="text-center t-20 w-full c-black p-5 font-weight-bold"></Label>
+        </StackLayout>
       </StackLayout>
     </ng-template>
   </ListView>
-</StackLayout>
+  </StackLayout>

--- a/apps/mobile/app/modules/misc/components/media.component.html
+++ b/apps/mobile/app/modules/misc/components/media.component.html
@@ -2,11 +2,13 @@
 <StackLayout class="page h-full p-b-20" *ngIf="renderView">
   <ListView [items]="mediaState$ | async" class="list-group h-full">
     <ng-template let-item="item" let-odd="odd" let-even="even">
-      <StackLayout class="card" (tap)="viewSite(item.link, item.name)">
-        <Image [src]="item.logo" height="120" horizontalAlignment="center" verticalAlignment="center" class="w-full p-5 c-bg-white"></Image>
-        
-        <!-- <StackLayout class="hr-light"></StackLayout> -->
-        <Label [text]="item.name" class="text-center t-20 w-full c-black p-5 font-weight-bold"></Label>
+      <StackLayout shadow="5">
+        <StackLayout class="card" (tap)="viewSite(item.link, item.name)">
+          <Image [src]="item.logo" height="120" horizontalAlignment="center" verticalAlignment="center" class="w-full p-5 c-bg-white"></Image>
+
+          <!-- <StackLayout class="hr-light"></StackLayout> -->
+          <Label [text]="item.name" class="text-center t-20 w-full c-black p-5 font-weight-bold"></Label>
+        </StackLayout>
       </StackLayout>
     </ng-template>
   </ListView>

--- a/apps/mobile/app/modules/shared/shared.module.ts
+++ b/apps/mobile/app/modules/shared/shared.module.ts
@@ -13,6 +13,7 @@ import { NativeScriptUISideDrawerModule } from 'nativescript-pro-ui/sidedrawer/a
 import { NativeScriptUIListViewModule } from 'nativescript-pro-ui/listview/angular';
 import { TNSFontIconModule } from 'nativescript-ngx-fonticon';
 import { TNSCheckBoxModule } from 'nativescript-checkbox/angular';
+import { NgShadowModule } from 'nativescript-ng-shadow';
 
 // app
 import { SHARED_COMPONENTS, SHARED_ENTRY_COMPONENTS } from './components';
@@ -29,6 +30,7 @@ const SHARED_MODULES: any[] = [
   TranslateModule,
   TNSFontIconModule,
   TNSCheckBoxModule,
+  NgShadowModule,
 ];
 
 @NgModule({

--- a/apps/mobile/app/modules/speakers/components/speaker.component.html
+++ b/apps/mobile/app/modules/speakers/components/speaker.component.html
@@ -2,8 +2,8 @@
 <StackLayout height="100%" class="page h-full p-b-20" (loaded)="onBackgroundLoaded($event)" *ngIf="renderView">
   <!-- Search -->
   <AbsoluteLayout>
-    <GridLayout rows="*" top="0" left="0" height="100%" width="100%" columns="*,15" class="list-background ">
-      <ListView #speakerList height="100%" width="100%" [items]="speakerState$ | async" class="list-group h-full">
+    <GridLayout rows="*" top="0" left="0" height="100%" width="100%" columns="15,*,15" class="list-background ">
+      <ListView row="0" col="1" #speakerList height="100%" width="100%" [items]="speakerState$ | async" class="list-group h-full">
         <ng-template let-item="item" let-odd="odd" let-even="even" let-index="index">
           <StackLayout shadow="5">
             <StackLayout [class.first-item]="index == 0" class="card" (tap)="openDetail(item)">
@@ -14,7 +14,7 @@
           </StackLayout>
         </ng-template>
       </ListView>
-      <StackLayout (touch)="slide($event)" row="0" col="1" class="letter-wrap">
+      <StackLayout (touch)="slide($event)" row="0" col="2" class="letter-wrap">
         <Label [text]="char" *ngFor="let char of alphabet" textWrap="true"></Label>
       </StackLayout>
     </GridLayout>

--- a/apps/mobile/app/modules/speakers/components/speaker.component.html
+++ b/apps/mobile/app/modules/speakers/components/speaker.component.html
@@ -5,10 +5,12 @@
     <GridLayout rows="*" top="0" left="0" height="100%" width="100%" columns="*,15" class="list-background ">
       <ListView #speakerList height="100%" width="100%" [items]="speakerState$ | async" class="list-group h-full">
         <ng-template let-item="item" let-odd="odd" let-even="even" let-index="index">
-          <StackLayout [class.first-item]="index == 0" class="card" (tap)="openDetail(item)">
-            <Image [src]="item.image" horizontalAlignment="center" class="w-full" backgroundColor="#fff"></Image>
-            <!-- <StackLayout class="hr-light"></StackLayout> -->
-            <Label [text]="item.name" class="text-center t-30 c-grey-dark font-weight-bold m-t-5"></Label>
+          <StackLayout shadow="5">
+            <StackLayout [class.first-item]="index == 0" class="card" (tap)="openDetail(item)">
+              <Image [src]="item.image" horizontalAlignment="center" class="w-full" backgroundColor="#fff"></Image>
+              <!-- <StackLayout class="hr-light"></StackLayout> -->
+              <Label [text]="item.name" class="text-center t-30 c-grey-dark font-weight-bold m-t-5"></Label>
+            </StackLayout>
           </StackLayout>
         </ng-template>
       </ListView>

--- a/apps/mobile/app/modules/sponsors/components/sponsor.component.html
+++ b/apps/mobile/app/modules/sponsors/components/sponsor.component.html
@@ -2,12 +2,15 @@
 <StackLayout class="page h-full p-b-20" *ngIf="renderView">
   <ListView [items]="(sponsorState$ | async)?.list" class="list-group h-full">
     <ng-template let-item="item" let-odd="odd" let-even="even">
-      <StackLayout class="card sponsor-card" (tap)="viewSite(item)" [ngClass]="item.level[0].styleClass">
-        <Image [src]="item.image" height="120" horizontalAlignment="center" verticalAlignment="center" class="w-full p-5 c-bg-white"></Image>
-        
-        <!-- <StackLayout class="hr-light"></StackLayout> -->
-        <Label [text]="item.name" class="text-center h2 w-full c-white p-5 font-weight-bold"></Label>
-        <Label [text]="level.name" class="level text-center h3 c-white p-2 w-full font-weight-bold" [ngClass]="level.styleClass" *ngFor="let level of item.level"></Label>
+      <StackLayout shadow="5">
+        <StackLayout class="card sponsor-card" (tap)="viewSite(item)" [ngClass]="item.level[0].styleClass">
+          <Image [src]="item.image" height="120" horizontalAlignment="center" verticalAlignment="center" class="w-full p-5 c-bg-white"></Image>
+
+          <!-- <StackLayout class="hr-light"></StackLayout> -->
+          <Label [text]="item.name" class="text-center h2 w-full c-white p-5 font-weight-bold"></Label>
+          <Label [text]="level.name" class="level text-center h3 c-white p-2 w-full font-weight-bold" [ngClass]="level.styleClass"
+            *ngFor="let level of item.level"></Label>
+        </StackLayout>
       </StackLayout>
     </ng-template>
   </ListView>

--- a/apps/mobile/app/scss/_common.scss
+++ b/apps/mobile/app/scss/_common.scss
@@ -345,7 +345,7 @@ ListView {
     background-color:rgba(21,31,47,.8);
 }
 .first-item{
-    padding-top: 50;
+    margin-top: 50;
 }
 .letter-wrap{
 	margin-top: 160;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -43,6 +43,7 @@
     "nativescript-iqkeyboardmanager": "~1.2.0",
     "nativescript-loading-indicator": "~2.4.0",
     "nativescript-local-notifications": "^2.0.2",
+    "nativescript-ng-shadow": "^2.1.0",
     "nativescript-ngx-fonticon": "~4.0.0",
     "nativescript-permissions": "^1.2.3",
     "nativescript-phone": "^1.3.1",
@@ -53,6 +54,7 @@
     "reflect-metadata": "~0.1.8",
     "rxjs": "file:../../node_modules/rxjs",
     "tns-core-modules": "~3.4.0",
+    "tns-ios": "3.4.0",
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -54,7 +54,6 @@
     "reflect-metadata": "~0.1.8",
     "rxjs": "file:../../node_modules/rxjs",
     "tns-core-modules": "~3.4.0",
-    "tns-ios": "3.4.0",
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {


### PR DESCRIPTION
adds a drop shadow to Media, Community, Sponsors, and Speakers list item cards. Also made the speaker card have the same amount of padding as the right side on the left side. 

<img width="417" alt="screen shot 2018-01-14 at 7 48 15 pm" src="https://user-images.githubusercontent.com/1486275/34922953-6341e812-f964-11e7-9831-1ad3b0a672e4.png">
<img width="415" alt="screen shot 2018-01-14 at 7 48 24 pm" src="https://user-images.githubusercontent.com/1486275/34922954-6353f2a0-f964-11e7-883f-8e3b2ec66450.png">
<img width="422" alt="screen shot 2018-01-14 at 7 51 06 pm" src="https://user-images.githubusercontent.com/1486275/34922955-636386c0-f964-11e7-858b-ea4d082fdabd.png">
