### PR TITLE
fix(router-configuration): use '~' alias for lazy modules paths

### DIFF
--- a/apps/mobile/app/modules/home/home.module.ts
+++ b/apps/mobile/app/modules/home/home.module.ts
@@ -20,27 +20,19 @@ const routes: Routes = [
       },
       {
         path: 'speakers',
-        loadChildren: './modules/speakers/speaker.module#SpeakerModule'
-        // NOTE for webpack: comment out above and uncomment below 
-        // loadChildren: '../speakers/speaker.module#SpeakerModule'
+        loadChildren: '~/modules/speakers/speaker.module#SpeakerModule'
       },
       {
         path: 'sponsors',
-        loadChildren: './modules/sponsors/sponsor.module#SponsorModule'
-        // NOTE for webpack: comment out above and uncomment below 
-        // loadChildren: '../sponsors/sponsor.module#SponsorModule'
+        loadChildren: '~/modules/sponsors/sponsor.module#SponsorModule'
       },
       {
         path: 'events',
-        loadChildren: './modules/events/events.module#EventsModule'
-        // NOTE for webpack: comment out above and uncomment below 
-        // loadChildren: '../events/events.module#EventsModule'
+        loadChildren: '~/modules/events/events.module#EventsModule'
       },
       {
         path: 'misc',
-        loadChildren: './modules/misc/misc.module#MiscModule'
-        // NOTE for webpack: comment out above and uncomment below 
-        // loadChildren: '../misc/misc.module#MiscModule'
+        loadChildren: '~/modules/misc/misc.module#MiscModule'
       },
     ]
   }


### PR DESCRIPTION
The '~' is alias to the app/ folder and works the same both with and
without webpack.