### PR TITLE
fix(uglify): exclude side drawer transitions from mangling

### DIFF
--- a/apps/mobile/webpack.config.js
+++ b/apps/mobile/webpack.config.js
@@ -162,18 +162,29 @@ module.exports = env => {
     //     compress,
     // }));
 
+
+    const nativescriptProUIMangleExcludes = [
+        "PushTransition",
+        "FadeTransition",
+        "SlideInOnTopTransition",
+    ];
+
     config.plugins.push(new ParallelUglifyPlugin({
       workerCount: os.cpus().length,
       uglifyES: {
         compress: platform !== 'android',
         mangle: {
-          reserved: nsWebpack.uglifyMangleExcludes
+            reserved: [
+                ...nsWebpack.uglifyMangleExcludes,
+                ...nativescriptProUIMangleExcludes,
+            ]
         },
         ecma: 6,
         safari10: platform !== 'android',
         warnings: 'verbose'
       }
     }));
+
     // config.plugins.push(new ClosureCompilerPlugin({
     //   compiler: {
     //     language_in: 'ES6',


### PR DESCRIPTION
The transitions of the sidedrawer UI control are compared using the constructor name of the
transition class. That's why these should be excluded from mangling.