### PR TITLE
Adding override styling for speaker section search bar on Android.

### DIFF
--- a/apps/mobile/app/scss/_android-overrides.scss
+++ b/apps/mobile/app/scss/_android-overrides.scss
@@ -14,13 +14,13 @@ Button {
 @keyframes session-favorite-selected {
   from { transform: scale(1, 1) rotate(-120); opacity: 0; animation-timing-function: linear; }
   50% { transform: scale(2, 2) rotate(-60); opacity: 0.3; animation-timint-function: ease-in; }
-  to { transform: scale(1, 1) rotate(0); opacity: 1; }    
+  to { transform: scale(1, 1) rotate(0); opacity: 1; }
 }
 
 @keyframes session-favorite-unselected {
   from { transform: scale(1, 1) rotate(120); opacity: 0; animation-timing-function: linear; }
   60% { transform: scale(2, 2) rotate(60); opacity: 0.3; animation-timint-function: ease-in; }
-  to { transform: scale(1, 1) rotate(0); opacity: 1; }    
+  to { transform: scale(1, 1) rotate(0); opacity: 1; }
 }
 
 .schedule-main-content {
@@ -28,18 +28,18 @@ Button {
       background-color: #4ac1fa;
       color: white;
     }
-    
+
     SearchBar {
       background-color: white;
       margin: 16;
     }
-    
+
     .session-favorite {
       vertical-align: center;
       horizontal-align: center;
       margin: 0 26 0 16;
     }
-    
+
     .session-favorite-selected {
       animation-name: session-favorite-selected;
       animation-duration: 0.4;
@@ -47,7 +47,7 @@ Button {
       horizontal-align: center;
       margin: 0 26 0 16;
     }
-    
+
     .session-favorite-unselected {
       animation-name: session-favorite-unselected;
       animation-duration: 0.2;
@@ -55,7 +55,7 @@ Button {
       horizontal-align: center;
       margin: 0 26 0 16;
     }
-    
+
     .session-time {
       font-family: "sans-serif";
       /*font-weight: 700;*/
@@ -63,7 +63,7 @@ Button {
       color: #4ac1fa;
       margin-top: 16;
     }
-    
+
     .session-room {
       font-family: "sans-serif";
       /*font-weight: 700;*/
@@ -72,7 +72,7 @@ Button {
       text-transform: uppercase;
       margin: 16 0 0 4;
     }
-    
+
     .session-title {
       font-family: "sans-serif";
       /*font-weight: 300;*/
@@ -80,4 +80,12 @@ Button {
     color: #c3c3c3;
       margin-bottom: 16;
     }
+}
+
+
+.search-bar{
+  padding: 10 5;
+}
+.search-bar SearchBar{
+  background-color: white;
 }


### PR DESCRIPTION
Booted up the app in an android emulator and noticed that the search bar color was blending in with the background. Also added some padding so the search bar does not take up the full wrapping container and looks similar to how it does on ios.

before 
![image](https://user-images.githubusercontent.com/1486275/35005312-00a100cc-fac1-11e7-95c7-66a0b7a94a08.png)

now
![image](https://user-images.githubusercontent.com/1486275/35005203-a662e184-fac0-11e7-9d53-bc982ac3091b.png)
